### PR TITLE
Fix inconsequential typo

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -39,11 +39,11 @@ function LeastSquaresProblem(;x = error("initial x required"), y = nothing, f! =
     if typeof(g!) == Nothing
         if autodiff == :central
             central_cache = FiniteDiff.JacobianCache(similar(x), similar(y), similar(y))
-            newg! = (J::Matrix, xp::Vector) -> FiniteDiff.finite_difference_jacobian!(J, f!, x, central_cache)
+            newg! = (J::Matrix, xp::Vector) -> FiniteDiff.finite_difference_jacobian!(J, f!, xp, central_cache)
         elseif autodiff == :forward
             jac_cfg = ForwardDiff.JacobianConfig(f!, y, x, ForwardDiff.Chunk(x))
             ForwardDiff.checktag(jac_cfg, f!, x)
-            newg! = (J::Matrix, xp::Vector) -> ForwardDiff.jacobian!(J, f!, deepcopy(y), x, jac_cfg, Val{false}())
+            newg! = (J::Matrix, xp::Vector) -> ForwardDiff.jacobian!(J, f!, deepcopy(y), xp, jac_cfg, Val{false}())
         else
             throw(DomainError(autodiff, "Invalid automatic differentiation method."))
         end


### PR DESCRIPTION
The moment `g!(J,x)` is [called](https://github.com/matthieugomez/LeastSquaresOptim.jl/blob/5c638d987d863e91313be3f4900a426d78453ba1/src/optimizer/dogleg.jl#L88) `anls.x` is the same as `x`, so it is inconsequential for the optimization. But when `anls.g!` is called outside of `LeastSquaresOptim`, the typo matters.