### PR TITLE
added abs value in denominator to prevent reversals

### DIFF
--- a/src/optimizer/levenberg_marquardt.jl
+++ b/src/optimizer/levenberg_marquardt.jl
@@ -113,7 +113,7 @@ function optimize!(
         mul_calls += 1
         axpy!(-one(eTy), fcur, fpredict)
         predicted_ssr = sum(abs2, fpredict)
-        ρ = (ssr - trial_ssr) / (ssr - predicted_ssr)
+        ρ = (ssr - trial_ssr) / abs(ssr - predicted_ssr)
         mul!(dtd, J', fcur, one(eTx), zero(eTx))
         maxabs_gr = maximum(abs, dtd)
         mul_calls += 1


### PR DESCRIPTION
I noticed that the Levenberg-Marquardt implementation in some cases does not monotonically reduce the function value each step. I think this is because the denominator in the ratio $\rho$ used to make the accept / reject decision can be negative (I think most likely when the step size is truncated to avoid exceeding one of the bounds, or perhaps when $J$ is imprecisely estimated by finite differences). In this case, a step that increases the function value may be accepted. I added an absolute value to the denominator in the ratio to eliminate this possibility. The edited version with `abs()` in the denominator matches the mathematical definition given [here](https://people.duke.edu/~hpgavin/ExperimentalSystems/lm.pdf) (eq. 14).