### PR TITLE
Declare compatibility with Optim v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LeastSquaresOptim"
 uuid = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
-version = "0.8.7"
+version = "0.8.8"
 
 [deps]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
@@ -15,7 +15,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [compat]
 FiniteDiff = "2"
 ForwardDiff = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 1.0"
-Optim = "0.19, 0.20, 0.21, 0.22, 1.0"
+Optim = "0.19, 0.20, 0.21, 0.22, 1.0, 2.0"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
Optim v2 was a breaking release but it should not affect the usage of this package since you only import and extend the `optimize` function