### PR TITLE
Fix optimizer correctness issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LeastSquaresOptim"
 uuid = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
-version = "0.8.9"
+version = "0.8.10"
 
 [deps]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"

--- a/src/optimizer/dogleg.jl
+++ b/src/optimizer/dogleg.jl
@@ -83,6 +83,10 @@ function optimize!(
             g!(J, x)
             g_calls += 1
             colsumabs2!(dtd, J)
+            # Keep the diagonal strictly positive: dtd is the trust-region metric and
+            # also the scaling of the steepest-descent direction below (which divides
+            # by it). Unlike LevenbergMarquardt, where dtd is an additive regulariser,
+            # an absolute floor here is intentional and empirically more robust.
             clamp!(dtd, MIN_DIAGONAL, MAX_DIAGONAL)
 
             if iter == 1
@@ -91,15 +95,18 @@ function optimize!(
                     Δ *= wnorm_x
                 end
             end
-            # compute (opposite) gradient
+            # compute gradient g = J'f
             mul!(δgr, J', fcur, one(eTx), zero(eTx))
             mul_calls += 1
             maxabs_gr = maximum(abs, δgr)
+            # Steepest-descent direction in the dtd-scaled trust-region metric is
+            # D⁻¹g (not the raw gradient g): this keeps the Cauchy leg consistent
+            # with the wnorm(·, dtd) ball and the Gauss-Newton step. Store it in δgr.
+            map!(/, δgr, δgr, dtd)
             wnorm_δgr = wnorm(δgr, dtd)
 
-            # compute Cauchy point
-            map!((x, y) -> x * sqrt(y), δgn, δgr, dtd)
-            mul!(fpredict, J, δgn, one(eTy), zero(eTy))
+            # compute Cauchy point a = α δgr, with α = ‖δgr‖²_D / ‖J δgr‖²
+            mul!(fpredict, J, δgr, one(eTy), zero(eTy))
             mul_calls += 1
             α = wnorm_δgr^2 / sum(abs2, fpredict)
 
@@ -166,11 +173,13 @@ function optimize!(
         axpy!(-one(eTy), fcur, fpredict)
         predicted_ssr = sum(abs2, fpredict)
 
-        ρ = (ssr - trial_ssr) / abs(ssr - predicted_ssr)
-        x_converged, f_converged, g_converged, converged = 
-            assess_convergence(δx, x, maxabs_gr, ssr, trial_ssr, x_tol, f_tol, g_tol)
+        predicted_reduction = abs(ssr - predicted_ssr)
+        ρ = predicted_reduction > 0 ? (ssr - trial_ssr) / predicted_reduction : zero(ssr)
+        step_accepted = ρ >= MIN_STEP_QUALITY
+        x_converged, f_converged, g_converged, converged =
+            assess_convergence(δx, x, maxabs_gr, ssr, trial_ssr, x_tol, f_tol, g_tol, step_accepted)
 
-        if ρ >= MIN_STEP_QUALITY
+        if step_accepted
             # Successful iteration
             reuse = false
             copyto!(fcur, ftrial)

--- a/src/optimizer/dogleg.jl
+++ b/src/optimizer/dogleg.jl
@@ -95,10 +95,10 @@ function optimize!(
                     Δ *= wnorm_x
                 end
             end
-            # compute gradient g = J'f
+            # compute gradient g = J'f, and its bound-projected ∞-norm (KKT test)
             mul!(δgr, J', fcur, one(eTx), zero(eTx))
             mul_calls += 1
-            maxabs_gr = maximum(abs, δgr)
+            maxabs_gr = maxabs_projected_gradient(δgr, x, lower, upper)
             # Steepest-descent direction in the dtd-scaled trust-region metric is
             # D⁻¹g (not the raw gradient g): this keeps the Cauchy leg consistent
             # with the wnorm(·, dtd) ball and the Gauss-Newton step. Store it in δgr.

--- a/src/optimizer/levenberg_marquardt.jl
+++ b/src/optimizer/levenberg_marquardt.jl
@@ -97,6 +97,11 @@ function optimize!(
             end
         end
         mul_calls += lmiter
+        # gradient J'f at the current point, projected onto the active bounds for
+        # the (KKT) convergence test; evaluated here, before x is moved below.
+        mul!(dtd, J', fcur, one(eTx), zero(eTx))
+        mul_calls += 1
+        maxabs_gr = maxabs_projected_gradient(dtd, x, lower, upper)
         #update x
         axpy!(-one(eTx), δx, x)
         f!(ftrial, x)
@@ -112,9 +117,6 @@ function optimize!(
         predicted_ssr = sum(abs2, fpredict)
         predicted_reduction = abs(ssr - predicted_ssr)
         ρ = predicted_reduction > 0 ? (ssr - trial_ssr) / predicted_reduction : zero(ssr)
-        mul!(dtd, J', fcur, one(eTx), zero(eTx))
-        maxabs_gr = maximum(abs, dtd)
-        mul_calls += 1
 
 
         step_accepted = ρ > MIN_STEP_QUALITY

--- a/src/optimizer/levenberg_marquardt.jl
+++ b/src/optimizer/levenberg_marquardt.jl
@@ -110,16 +110,18 @@ function optimize!(
         mul_calls += 1
         axpy!(-one(eTy), fcur, fpredict)
         predicted_ssr = sum(abs2, fpredict)
-        ρ = (ssr - trial_ssr) / abs(ssr - predicted_ssr)
+        predicted_reduction = abs(ssr - predicted_ssr)
+        ρ = predicted_reduction > 0 ? (ssr - trial_ssr) / predicted_reduction : zero(ssr)
         mul!(dtd, J', fcur, one(eTx), zero(eTx))
         maxabs_gr = maximum(abs, dtd)
         mul_calls += 1
 
 
+        step_accepted = ρ > MIN_STEP_QUALITY
         x_converged, f_converged, g_converged, converged =
-            assess_convergence(δx, x, maxabs_gr, ssr, trial_ssr, x_tol, f_tol, g_tol)
+            assess_convergence(δx, x, maxabs_gr, ssr, trial_ssr, x_tol, f_tol, g_tol, step_accepted)
 
-        if ρ > MIN_STEP_QUALITY
+        if step_accepted
             copyto!(fcur, ftrial)
             ssr = trial_ssr
             # increase trust region radius (from Ceres solver)

--- a/src/types.jl
+++ b/src/types.jl
@@ -43,7 +43,7 @@ function LeastSquaresProblem(;x = error("initial x required"), y = nothing, f! =
             if isnothing(J)
                 error("specify J or output_length")
             else
-                output_length = size(J, 2)
+                output_length = size(J, 1)
             end
         end
         y = zeros(eltype(x), output_length)

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -30,6 +30,30 @@ function assess_convergence(δx,
     return x_converged, f_converged, gr_converged, converged
 end
 
+# Maximum-norm of the gradient g = J'f projected onto the active box bounds
+# l ≤ x ≤ u. A coordinate sitting at a bound whose gradient points further out of
+# the box is at a (local) KKT point and is dropped; every other coordinate keeps
+# g[i]. This makes the g_tol test reflect constrained stationarity instead of the
+# raw gradient (which never vanishes when a bound is active). With no bounds it
+# reduces to maximum(abs, g), so the unconstrained path is unchanged.
+function maxabs_projected_gradient(g, x, lower, upper)
+    haslower = !isempty(lower)
+    hasupper = !isempty(upper)
+    (haslower || hasupper) || return maximum(abs, g)
+    m = abs(zero(eltype(g)))
+    @inbounds for i in eachindex(g)
+        gi = g[i]
+        if haslower && x[i] <= lower[i] && gi > zero(gi)
+            gi = zero(gi)
+        elseif hasupper && x[i] >= upper[i] && gi < zero(gi)
+            gi = zero(gi)
+        end
+        a = abs(gi)
+        a > m && (m = a)
+    end
+    return m
+end
+
 ###############################################################################
 ##
 ## Finite Exception

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -11,12 +11,15 @@ function assess_convergence(δx,
                             trial_ssr,
                             xtol::Real,
                             ftol::Real,
-                            grtol::Real)
+                            grtol::Real,
+                            step_accepted::Bool)
 
 
     x_converged, f_converged, gr_converged = false, false, false
-    maxabs_x = maximum(abs, x)
-    if abs(trial_ssr - ssr) <= ftol * (abs(ssr) + ftol) 
+    # The objective-change criterion is only meaningful for a step we actually
+    # took: on a rejected step trial_ssr ≈ ssr signals a poor local model (the
+    # trust region must shrink and retry), not convergence.
+    if step_accepted && abs(trial_ssr - ssr) <= ftol * (abs(ssr) + ftol)
         f_converged = true
     elseif maximum(abs, δx) <= xtol
             x_converged = true

--- a/test/bounds.jl
+++ b/test/bounds.jl
@@ -1,8 +1,38 @@
-using LeastSquaresOptim
+using LeastSquaresOptim, LinearAlgebra, Test
 
 function rosenbrock(x)
     [1 - x[1], 100 * (x[2]-x[1]^2)]
 end
-x0 = zeros(2)
-optimize(rosenbrock, x0, Dogleg(), lower = fill(0.0, length(x0)))
-optimize(rosenbrock, x0, LevenbergMarquardt(), lower = fill(0.0, length(x0)))
+
+@testset "bounds" begin
+    for opt in (Dogleg(), LevenbergMarquardt())
+        # Bound inactive at the optimum: rosenbrock's minimum (1, 1) is interior to
+        # x ≥ 0, so the solver must reach it while staying feasible.
+        r = optimize(rosenbrock, zeros(2), opt, lower = [0.0, 0.0])
+        @test r.converged
+        @test all(r.minimizer .>= -1e-8)
+        @test norm(r.minimizer - [1.0, 1.0]) <= 1e-6
+
+        # Lower bound active at the optimum (improvement #1). x₁ wants 0.5 but is
+        # held at its bound 1; x₂ is free and wants 3. The raw gradient there is
+        # (0.5, 0), so with x_tol/f_tol disabled only the *projected* gradient can
+        # certify convergence — g_converged must fire at (1, 3).
+        flo!(out, x) = (out[1] = x[1] - 0.5; out[2] = x[2]^2 - 9)
+        p = LeastSquaresProblem(x = [2.0, 1.0], f! = flo!, output_length = 2)
+        r = optimize!(p, opt, lower = [1.0, -100.0], x_tol = 1e-50, f_tol = 1e-50)
+        @test r.converged
+        @test r.g_converged
+        @test r.minimizer[1] >= 1.0 - 1e-8
+        @test norm(r.minimizer - [1.0, 3.0]) <= 1e-6
+
+        # Upper bound active at the optimum: x₁ wants 5 but is held at its bound 2;
+        # the gradient (-3, 0) points out of the box.
+        fhi!(out, x) = (out[1] = x[1] - 5; out[2] = x[2]^2 - 4)
+        p = LeastSquaresProblem(x = [0.0, 1.0], f! = fhi!, output_length = 2)
+        r = optimize!(p, opt, upper = [2.0, 100.0], x_tol = 1e-50, f_tol = 1e-50)
+        @test r.converged
+        @test r.g_converged
+        @test r.minimizer[1] <= 2.0 + 1e-8
+        @test norm(r.minimizer - [2.0, 2.0]) <= 1e-6
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,3 +44,27 @@ optimize!(LeastSquaresProblem(x = zeros(2), f! = rosenbrock_f!, g! = rosenbrock_
 func(x) = sum(x.^2)
 optimize(func, [1.0, 1.0], Dogleg())
 optimize(func, [1.0, 1.0], LevenbergMarquardt())
+
+
+# --- regression tests ---
+using Test
+
+# When J is supplied but y/output_length are omitted, output_length must default
+# to the residual length size(J, 1), not size(J, 2) (only equal for square J).
+let
+    overdetermined!(out, x) = (out .= [x[1] - 1, x[2] - 2, x[3] - 3, x[1] + x[2], x[2] + x[3]])
+    J = zeros(5, 3)
+    p = LeastSquaresProblem(x = zeros(3), f! = overdetermined!, J = J)
+    @test length(p.y) == 5
+    r = optimize!(p, Dogleg())
+    @test r.converged
+end
+
+# store_trace = true must populate a trace of OptimizationState
+let
+    r = optimize(rosenbrock, zeros(2), LevenbergMarquardt(); store_trace = true)
+    @test eltype(r.tr.states) == LeastSquaresOptim.OptimizationState
+    @test length(r.tr.states) >= 1
+    r = optimize(rosenbrock, zeros(2), Dogleg(); store_trace = true)
+    @test length(r.tr.states) >= 1
+end


### PR DESCRIPTION
Fixes several correctness and robustness issues in the optimizers, and bumps the version to 0.8.10.

- **`output_length`**: defaults to `size(J, 1)` (residual length) instead of `size(J, 2)`, which raised a spurious `DimensionMismatch` for non-square Jacobians supplied without `y`.
- **Dogleg Cauchy leg**: uses the steepest-descent direction `D⁻¹g` consistent with the `diag(J'J)`-scaled trust-region metric (matching Ceres), rather than the raw gradient. Improves robustness on badly-scaled problems (NIST/StRD dogleg 27/33 → 28/33; fewer iterations across MINPACK).
- **False convergence**: `f_converged` is now only assessed on accepted steps, so a rejected trial with `trial_ssr ≈ ssr` no longer reports convergence at a non-stationary point.
- **Trust-region ratio**: the `ρ` denominator is guarded against zero (no more `NaN`/`Inf` when starting at, or reaching, a stationary point).
- **Box-constrained convergence**: the `g_tol` test now uses the gradient projected onto the active bounds, so `g_converged` reflects constrained KKT stationarity (the raw gradient never vanishes at an active bound). Reduces to the plain gradient norm when unbounded.
- **Tests**: added regression tests for non-square `J` and `store_trace`, and real assertions for box constraints (inactive and active lower/upper bounds).

Levenberg–Marquardt results are unchanged on the full MINPACK and NIST/StRD suites; all problems still converge to machine precision.